### PR TITLE
Add npc & map name dropdowns

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     api(project(":darkbot-shared"))
 }
 
-val apiVersion = "0.7.5"
+val apiVersion = "0.7.6"
 
 allprojects {
     group = "eu.darkbot"

--- a/shared/src/main/java/eu/darkbot/shared/config/MapNames.java
+++ b/shared/src/main/java/eu/darkbot/shared/config/MapNames.java
@@ -1,0 +1,48 @@
+package eu.darkbot.shared.config;
+
+import eu.darkbot.api.config.annotations.Dropdown;
+import eu.darkbot.api.game.other.GameMap;
+import eu.darkbot.api.managers.StarSystemAPI;
+import eu.darkbot.api.utils.Inject;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A dropdown options implementation that gives maps as options, saving the map id.
+ */
+public class MapNames implements Dropdown.Options<Integer> {
+    private final List<Integer> maps;
+    private final StarSystemAPI starSystemAPI;
+
+    @Inject
+    public MapNames(StarSystemAPI starSystemAPI) {
+        this(starSystemAPI, starSystemAPI.getMaps().stream()
+                .map(GameMap::getId)
+                .filter(id -> id > 0) // Filter out fake maps
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Alternative constructor, left to allow for extension by providing your own list of maps or way of filtering.
+     * @param starSystemAPI The star system api
+     * @param maps The list of map ids to make available.
+     */
+    public MapNames(StarSystemAPI starSystemAPI, List<Integer> maps) {
+        this.starSystemAPI = starSystemAPI;
+        this.maps = maps;
+    }
+
+    @Override
+    public Collection<Integer> options() {
+        return maps;
+    }
+
+    @Override
+    public @NotNull String getText(Integer option) {
+        return option == null ? "null" : starSystemAPI.getOrCreateMap(option).getName();
+    }
+
+}

--- a/shared/src/main/java/eu/darkbot/shared/config/NpcNames.java
+++ b/shared/src/main/java/eu/darkbot/shared/config/NpcNames.java
@@ -1,0 +1,72 @@
+package eu.darkbot.shared.config;
+
+import eu.darkbot.api.config.ConfigSetting;
+import eu.darkbot.api.config.annotations.Dropdown;
+import eu.darkbot.api.game.entities.Npc;
+import eu.darkbot.api.managers.ConfigAPI;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * A dropdown options implementation that gives simplified NPC names as options.
+ * Example:
+ * <pre>
+ * <code>
+ * class Config {
+ *     {@literal @}Dropdown(options = NpcNames.class)
+ *     public String NPC_NAME = "";
+ *     {@literal @}Dropdown(options = NpcNames.class, multi=true)
+ *     public Set<String> NPC_NAMES = new HashSet<>();
+ * }
+ * class Feature {
+ *     private Config conf; // Assume populated
+ *
+ *     boolean isSelectedInConfig(Npc npc) {
+ *         String simpleName = NpcNames.getSimpleName(npc);
+ *         return conf.NPC_NAME.equals(simpleName) || conf.NPC_NAMES.contains(simpleName);
+ *     }
+ * }
+ * </code>
+ * </pre>
+ * In this example, the feature has a config with two dropdowns, one for a single npc, and another for multi-selection.
+ * The isSelectedInConfig function returns true if the npc is selected anywhere in the config.
+ */
+public class NpcNames implements Dropdown.Options<String> {
+
+    private final ConfigSetting<Map<String, ?>> npcInfos;
+    private boolean dirty = true;
+    private List<String> options;
+
+    public NpcNames(ConfigAPI configAPI) {
+        npcInfos = configAPI.requireConfig("loot.npc_infos");
+        npcInfos.addListener(val -> dirty = true);
+    }
+
+    @Override
+    public Collection<String> options() {
+        if (dirty) {
+            options = npcInfos.getValue().keySet().stream()
+                    .map(NpcNames::simplifyName)
+                    .distinct()
+                    .sorted()
+                    .collect(Collectors.toList());
+            dirty = false;
+        }
+        return options;
+    }
+
+    public static String simplifyName(String name) {
+        if (!name.matches("^\\D+\\d{1,3}$")) return name;
+        return name.replaceAll("\\d{1,3}$", " *");
+    }
+
+    public static String getSimpleName(Npc npc) {
+        if (npc == null) return null;
+        return simplifyName(npc.getEntityInfo().getUsername());
+    }
+
+}


### PR DESCRIPTION
Adds dropdown implementations to have npc & map lists in plugin configs.

These are new-api replacements for the original legacy option lists of `NpcNameSupplier` and `StarManager.MapList`.