### PR TITLE
Fix `ClassCastException` on escaping

### DIFF
--- a/shared/src/main/java/eu/darkbot/shared/utils/SafetyFinder.java
+++ b/shared/src/main/java/eu/darkbot/shared/utils/SafetyFinder.java
@@ -84,14 +84,20 @@ public class SafetyFinder implements Listener {
     public enum Escaping {
         ENEMY, SIGHT, REPAIR, REFRESH, WAITING, NONE;
         boolean canUse(SafetyInfo safety) {
-            if (safety.getType() == SafetyInfo.Type.CBS) {
-                BattleStation.Hull cbs = ((BattleStation.Hull) safety.getEntity().orElse(null));
-                if (cbs == null) return false;
-                // Ignore enemy CBS, and if set to ALLY only, ignore empty meteorites (hull = 0)
-                if (cbs.getEntityInfo().isEnemy() || (cbs.getHullId() == 0 && safety.getCbsMode() == SafetyInfo.CbsMode.ALLY)) return false;
-            }
-            return safety.getRunMode().ordinal() <= this.ordinal();
+
+            if(safety.getType() != SafetyInfo.Type.CBS)
+                return safety.getRunMode().ordinal() <= this.ordinal();
+
+            if(!(safety.getEntity().orElse(null) instanceof BattleStation.Hull))
+                return false;
+
+            BattleStation.Hull hull = (BattleStation.Hull) safety.getEntity().get();
+
+            // Ignore enemy CBS, and if set to ALLY only, ignore empty meteorites (hull = 0)
+            return !(hull.getEntityInfo().isEnemy() ||
+                    (hull.getHullId() == 0 && safety.getCbsMode() == SafetyInfo.CbsMode.ALLY));
         }
+
         boolean shouldJump(SafetyInfo safety) {
             SafetyInfo.JumpMode jm = safety.getJumpMode();
             if (safety.getType() != SafetyInfo.Type.PORTAL || jm == null) return false;


### PR DESCRIPTION
BattleStation.Asteroid cannot be cast to class BattleStation.Hull


```
at eu.darkbot.shared.utils.SafetyFinder$Escaping.canUse(SafetyFinder.java:88)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at eu.darkbot.shared.utils.SafetyFinder.getSafety(SafetyFinder.java:318)
	at eu.darkbot.shared.utils.SafetyFinder.activeTick(SafetyFinder.java:238)
	at eu.darkbot.shared.utils.SafetyFinder.tick(SafetyFinder.java:185)
	at eu.darkbot.shared.modules.LootModule.checkDangerousAndCurrentMap(LootModule.java:153)
	at eu.darkbot.shared.modules.LootCollectorModule.onTickModule(LootCollectorModule.java:55)
	at com.github.manolo8.darkbot.Main.tickLogic(Main.java:296)
	at com.github.manolo8.darkbot.Main.tickRunning(Main.java:290)
	at com.github.manolo8.darkbot.Main.validTick(Main.java:277)
	at com.github.manolo8.darkbot.Main.tick(Main.java:233)
	at com.github.manolo8.darkbot.Main.run(Main.java:204)
```